### PR TITLE
bugfix(uniform): generate immutable lookup table

### DIFF
--- a/src/uniform.jl
+++ b/src/uniform.jl
@@ -47,5 +47,5 @@ end
         x = reinterpret(T, raw_x)
         table[raw_x + 1] = _uq_round(UniformQuantization(N), x)
     end
-    return table
+    return Tuple(table)
 end


### PR DESCRIPTION
I forgot this when I put up the solution in https://github.com/adrhill/ColorQuantization.jl/pull/1#discussion_r984173068. Generated function can't return mutable data, otherwise, the precompiled result can be affected and may cause hard-to-understand bugs.